### PR TITLE
Turn the plugin into a macro

### DIFF
--- a/src/Keyboardio-LEDEffect-Numlock.h
+++ b/src/Keyboardio-LEDEffect-Numlock.h
@@ -1,17 +1,25 @@
 #pragma once
 
 #include "Keyboardio-LEDControl.h"
+#include "Keyboardio-Macros.h"
 #include "LEDUtils.h"
 
-class LEDNumlock : LEDMode {
+class NumLock_ : LEDMode {
  public:
-  LEDNumlock (uint8_t numpadIndex);
+  NumLock_ (void);
 
   virtual void begin (void) final;
 
   virtual void update (void) final;
   virtual void init (void) final;
 
+  static const macro_t *toggle (byte row, byte col, uint8_t numPadLayer);
+
  private:
-  static void loopHook (bool postClear);
+  static uint8_t previousLEDMode;
+  static uint8_t us;
+  static bool isActive;
+  static byte row, col;
 };
+
+extern NumLock_ NumLock;

--- a/src/Keyboardio-LEDEffect-Numlock.h
+++ b/src/Keyboardio-LEDEffect-Numlock.h
@@ -4,6 +4,9 @@
 #include "Keyboardio-Macros.h"
 #include "LEDUtils.h"
 
+#define TOGGLENUMLOCK 0
+#define Key_ToggleNumlock M(TOGGLENUMLOCK)
+
 class NumLock_ : LEDMode {
  public:
   NumLock_ (void);


### PR DESCRIPTION
The expected usage is now calling `NumLock.toggle(row, col, layer)` from within a macro.

Depends on keyboardio/Keyboardio-Macros#1.